### PR TITLE
feat: first version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.github
+.gitignore
+README.md

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    commit-message:
+      prefix: "chore"
+    schedule:
+      interval: "weekly"
+      day: "sunday"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Build and publish
+
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  dockerhub:
+    name: DockerHub
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          context: .
+          platforms: linux/amd64
+          tags: |
+            gatlingcorp/dedicated-load-generator:21-jre-headless
+            gatlingcorp/dedicated-load-generator:latest-jre-headless
+            gatlingcorp/dedicated-load-generator:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM debian:bookworm
+
+RUN apt-get update && \
+    apt-get install -y openssh-server gnupg ca-certificates curl jq && \
+    sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config && \
+    # Java 21 from Azul Zulu
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
+    apt-get update && \
+    apt-get install -y zulu21-jre-headless && \
+    # gatling-user User \
+    groupmod -g 1000 users && \
+    useradd -u 911 -U -d /config -s /bin/bash gatling-user && \
+    usermod -G users gatling-user && \
+    mkdir -p /config && \
+    # Gatling OS tuning \
+    echo "*       soft    nofile  65535\n*       hard    nofile  65535" >> /etc/security/limits.conf && \
+    echo "session required pam_limits.so" >> /etc/pam.d/sshd && \
+    # Cleanup
+    rm -rf \
+      /var/lib/apt/lists/* \
+      /tmp/* \
+      $HOME/.cache
+
+EXPOSE 22
+
+COPY /root /
+
+ENTRYPOINT ["/docker/docker-entrypoint"]
+CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Gatling Enterprise Certified Docker images for dedicated load generators
+
+These image is published to [Docker Hub](
+https://hub.docker.com/r/gatlingcorp/dedicated-load-generator).
+The purpose is to ease the configuration of a dedicated host for generating
+load with [Gatling Enterprise](https://gatling.io/products) (self-hosted or
+private locations for cloud).
+You can fork this repository or use the generated image as a base for your own
+needs.
+
+## Using the gatlingcorp/dedicated-load-generator image
+
+```console
+docker run \
+  --publish 22:22 \
+  --rm \
+  -e PUBLIC_KEY="$(cat ~/.ssh/id_ed25519.pub)" \
+  gatlingcorp/dedicated-load-generator
+```
+
+## Parameters
+
+|                            Parameter                             | Function                                                                                                |
+|:----------------------------------------------------------------:|---------------------------------------------------------------------------------------------------------|
+|                           `-p 2222:22`                           | ssh port                                                                                                |
+|                  `-e PUBLIC_KEY=yourpublickey`                   | Optional ssh public key, which will automatically be added to authorized_keys.                          |
+|                `-e PUBLIC_KEY_FILE=/path/to/file`                | Optionally specify a file in the container containing the public key (works with docker secrets).       |
+| `-e PUBLIC_KEY_DIR=/path/to/directory/containing/_only_/pubkeys` | Optionally specify a directory in the container containing the public keys (works with docker secrets). |
+|       `-e PUBLIC_KEY_URL=https://github.com/username.keys`       | Optionally specify a URL containing the public key.                                                     |
+|                   `-e USER_NAME=gatling-user`                    | Optionally specify a user name (Default:`gatling-user`)                                                 |
+
+You need at least to define one public key parameter.
+
+## What's inside
+
+ * debian bullseye base
+ * Azul Zulu openjdk 21
+ * jq
+ * curl
+
+## Developing
+
+```console
+docker buildx build --tag gatlingcorp/dedicated-load-generator:local .
+```

--- a/root/docker/docker-entrypoint
+++ b/root/docker/docker-entrypoint
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+USER_NAME=${USER_NAME:-gatling-user}
+echo "User name is set to $USER_NAME"
+
+PUID=${PUID:-911}
+PGID=${PGID:-911}
+
+if [[ "$USER_NAME" != "gatling-user" ]]; then
+  usermod -l "$USER_NAME" gatling-user
+  groupmod -n "$USER_NAME" gatling-user
+fi
+
+groupmod -o -g "$PGID" "$USER_NAME"
+usermod -o -u "$PUID" "$USER_NAME"
+
+echo "
+───────────────────────────────────────
+GID/UID
+───────────────────────────────────────
+User UID:    $(id -u "${USER_NAME}")
+User GID:    $(id -g "${USER_NAME}")
+───────────────────────────────────────
+"
+
+# create folders
+mkdir -p \
+    /config/{.ssh,ssh_host_keys,logs/openssh} \
+    /run/sshd
+
+# symlink out ssh config directory
+if [[ ! -L /etc/ssh ]]; then
+    if [[ ! -f /config/ssh_host_keys/sshd_config ]]; then
+        sed -i '/#PidFile/c\PidFile \/config\/sshd.pid' /etc/ssh/sshd_config
+        cp -a /etc/ssh/sshd_config /config/ssh_host_keys/
+    fi
+    rm -Rf /etc/ssh
+    ln -s /config/ssh_host_keys /etc/ssh
+    ssh-keygen -A
+fi
+
+# set umask for sftp
+UMASK=${UMASK:-022}
+sed -i "s|/usr/lib/ssh/sftp-server$|/usr/lib/ssh/sftp-server -u ${UMASK}|g" /etc/ssh/sshd_config
+
+# set key auth in file
+if [[ ! -f /config/.ssh/authorized_keys ]]; then
+    touch /config/.ssh/authorized_keys
+fi
+
+if [[ -n "$PUBLIC_KEY" ]]; then
+    if ! grep -q "${PUBLIC_KEY}" /config/.ssh/authorized_keys; then
+        echo "$PUBLIC_KEY" >> /config/.ssh/authorized_keys
+        echo "Public key from env variable added"
+    fi
+fi
+
+if [[ -n "$PUBLIC_KEY_URL" ]]; then
+    PUBLIC_KEY_DOWNLOADED=$(curl -s "$PUBLIC_KEY_URL")
+    if ! grep -q "$PUBLIC_KEY_DOWNLOADED" /config/.ssh/authorized_keys; then
+        echo "$PUBLIC_KEY_DOWNLOADED" >> /config/.ssh/authorized_keys
+        echo "Public key downloaded from '$PUBLIC_KEY_URL' added"
+    fi
+fi
+
+if [[ -n "$PUBLIC_KEY_FILE" ]] && [[ -f "$PUBLIC_KEY_FILE" ]]; then
+    PUBLIC_KEY2=$(cat "$PUBLIC_KEY_FILE")
+    if ! grep -q "$PUBLIC_KEY2" /config/.ssh/authorized_keys; then
+        echo "$PUBLIC_KEY2" >> /config/.ssh/authorized_keys
+        echo "Public key from file added"
+    fi
+fi
+
+if [[ -d "$PUBLIC_KEY_DIR" ]]; then
+    for F in "${PUBLIC_KEY_DIR}"/*; do
+        PUBLIC_KEYN=$(cat "$F")
+        if ! grep -q "$PUBLIC_KEYN" /config/.ssh/authorized_keys; then
+            echo "$PUBLIC_KEYN" >> /config/.ssh/authorized_keys
+            echo "Public key from file '$F' added"
+        fi
+    done
+fi
+
+# permissions
+chown -R "${USER_NAME}":"${USER_NAME}"  /config
+chmod go-w /config
+chmod 700 /config/.ssh
+chmod 600 /config/.ssh/authorized_keys
+
+DAEMON=sshd
+
+stop() {
+  echo "Received SIGINT or SIGTERM."
+  echo "Shutting down $DAEMON."
+  # Get PID
+  pid=$(cat "/var/run/$DAEMON/$DAEMON.pid")
+  # Signal the daemon
+  kill -SIGTERM "$pid"
+  # Wait for exit
+  wait "$pid"
+  # All done
+  echo "Exiting"
+}
+
+if [ "$(basename "$1")" == "$DAEMON" ]; then
+  echo "Starting $DAEMON"
+  trap stop SIGINT SIGTERM
+  "$@" &
+  pid="$!"
+  mkdir -p "/var/run/$DAEMON" && \
+    echo "$pid" > "/var/run/$DAEMON/$DAEMON.pid"
+  wait "$pid" && exit $?
+else
+  exec "$@"
+fi


### PR DESCRIPTION
Motivation:
Customer asked for a base image for our dedicated load generator.

Modifications:
From a debian base image, install openssh-server, java zulu 21, curl, jq Add some configuration to let the final user chose the available public key and the final username.
Document how to launch the image
Create GitHub workflows to publish this new image

Result:
A new image will be available on docker hub.
This should ease customer that work with docker in their dedicated machines.