### PR TITLE
fix: Default to the gatling-user user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,7 @@ EXPOSE 22
 
 COPY /root /
 
+USER gatling-user
+
 ENTRYPOINT ["/docker/docker-entrypoint"]
 CMD ["/usr/sbin/sshd", "-D", "-e"]


### PR DESCRIPTION
Avoid being flagged as a security risk due to using the root user by default. In practice, should make no difference as the launch script would switch to the same user by default.